### PR TITLE
投稿詳細機能

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,7 +14,16 @@
  *= require_self
  */
 
- /* 共通 */
+/* 共通 */
+
+ a {
+  text-decoration: none;
+}
+
+.main {
+  background: #f8f8f8;
+}
+
 .logo-name {
   color: black;
   text-decoration: none;

--- a/app/assets/stylesheets/posts/index.scss
+++ b/app/assets/stylesheets/posts/index.scss
@@ -1,13 +1,3 @@
-a {
-  text-decoration: none;
-}
-
-.main {
-  background: #f8f8f8;
-}
-
-
-
 /* 投稿一覧 */
 
 .index-map-contents {
@@ -72,6 +62,7 @@ a {
   padding: 2em 0.5em 1em;
   margin: 0.5em 0;
   border: solid 1px #FFC107;
+  height: 7em;
   position: relative;
 }
 

--- a/app/assets/stylesheets/posts/show.css
+++ b/app/assets/stylesheets/posts/show.css
@@ -1,0 +1,104 @@
+/* 投稿詳細 */
+
+.show-map-contents {
+  background-color: #FFF;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10vh 0;
+}
+
+.show-map-contents>.title {
+  font-size: 5vh;
+  font-weight: bold;
+  text-align: center;
+}
+
+.show-map-info {
+  width: 50vw;
+  background-color: #FFF;
+  color: black;
+  border: 1px solid #3ccace;
+  padding: 1vh 1vw;
+  margin: 1vh 1vw;
+  position: relative;  /* 3点リーダー用 */
+}
+
+.show-image {
+  height: 0;
+  overflow: hidden;
+  padding-bottom: 75%;
+  background-color: #f2f2f2;
+  position: relative;
+}
+
+.show-post-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto;
+  height: 100%;
+  width: auto;
+}
+
+.show-map-name {
+  font-size: 3vh;
+}
+
+.show-map-distance {
+  font-size: 3vh;
+  margin-top: 1vh;
+}
+
+.show-lists {
+  border-collapse: collapse;
+  border: 1px solid lightgray;
+  width: 100%;
+  margin: 3vh 0;
+}
+
+.show-list {
+  border: 1px solid lightgray;
+  padding: 0.3em;
+  width: 50%;
+}
+
+.answer {
+  border: 1px solid lightgray;
+  padding: 0.3em;
+  width: 50%;
+}
+
+.map-btn {
+  display: flex;
+  align-items: center;
+}
+
+.show-map-comment {
+  font-size: 2.5vh;
+  padding: 2em 0.5em 1em;
+  margin: 0.5em 0;
+  border: solid 1px #FFC107;
+  position: relative;
+}
+
+.show-map-comment .box-title {
+  position: absolute;
+  display: inline-block;
+  top: -1px;
+  left: -1px;
+  font-size: 2.5vh;
+  padding: 0 0.5em;
+  background: #FFC107;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.show-map-comment span {
+  margin: 0;
+  padding: 0;
+}
+
+/* //投稿詳細 */

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  before_action :post_find, only: %i[edit update destroy]
+  before_action :post_find, only: %i[show edit update destroy]
   before_action :authenticate_user!, except: %i[index show]
   before_action :move_to_index, only: %i[edit update destroy]
 
@@ -20,11 +20,13 @@ class PostsController < ApplicationController
     end
   end
 
+  def show; end
+
   def edit; end
 
   def update
     if @post.update(post_params)
-      redirect_to user_path(current_user.id)
+      redirect_to post_path(@post.id)
     else
       render :edit
     end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -8,29 +8,30 @@
     <ul class='map-lists'>
       <% @posts.each do |post| %>
       <li class='list'>
-        <%# <%= link_to post_path(post.id) do %>
         <div class='map-info'>
-          <h3 class='map-name'>
-            <%= link_to "このコースのマップを見る", post.map_link, target: :_blank, rel: "noopener noreferrer" %>
-          </h3>
+          <div class="index-user-name">
+            <%= link_to user_path(post.user.id) do %>
+              <span>投稿者：</span><%= post.user.nickname %>
+            <% end %>
+          </div>
+
+          <%= render "shared/leader", post: post %>
+
           <div class='index-image'>
             <%= image_tag post.image, class: 'post-image' if post.image.attached? %>
             <%= image_tag 'noimage.png', class: 'post-image' unless post.image.attached? %>
           </div>
-          <div class="index-user-name">
-            <a href="/users/<%= post.user.id %>">
-              <span>投稿者：</span><%= post.user.nickname %>
-            </a>
+          <div class='map-name'>
+            <%= link_to "このコースのマップを見る", post.map_link, target: :_blank, rel: "noopener noreferrer" %>
           </div>
           <div class='map-distance'>
             <span>コース距離：約<%= post.distance %>km</span>
           </div>
           <div class='map-comment'>
             <span class="box-title">コメント</span>
-            <span><%= post.comment %></span>
+            <span><%= truncate(post.comment, length: 40) %></span>
           </div>
         </div>
-        <%# <% end %>
       </li>
       <% end %>
     </ul>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,55 @@
+<%= render "shared/header" %>
+
+<div class='show-map-contents'>
+  <div class="title" >
+    投稿詳細
+  </div>
+  <div class='show-map-info'>
+    <div class="show-user-name">
+      <%= link_to user_path(@post.user.id) do %>
+        <span>投稿者：</span><%= @post.user.nickname %>
+      <% end %>
+    </div>
+
+    <%= render "shared/second-leader", post: @post %>
+
+    <div class='show-image'>
+      <%= image_tag @post.image, class: 'show-post-image' if @post.image.attached? %>
+      <%= image_tag 'noimage.png', class: 'show-post-image' unless @post.image.attached? %>
+    </div>
+    <div class='show-map-name'>
+      <%= link_to "このコースのマップを見る", @post.map_link, target: :_blank, rel: "noopener noreferrer" %>
+    </div>
+    <div class='show-map-distance'>
+      <span>コース距離：約<%= @post.distance %>km</span>
+    </div>
+    <table class='show-lists'>
+      <tr>
+        <td class='show-list'>山コース？ 海コース？</td>
+        <td class='answer'><%= @post.course %></td>
+      </tr>
+      <tr>
+        <td class='show-list'>坂の多さ</td>
+        <td class='answer'><%= @post.slope %></td>
+      </tr>
+      <tr>
+        <td class='show-list'>交通量</td>
+        <td class='answer'><%= @post.traffic %></td>
+      </tr>
+      <tr>
+        <td class='show-list'>人混みの多さ</td>
+        <td class='answer'><%= @post.crowd %></td>
+      </tr>
+      <tr>
+        <td class='show-list'>景色の良さ</td>
+        <td class='answer'><%= @post.view %></td>
+      </tr>
+    </table>
+    <div class='show-map-comment'>
+      <span class="box-title">コメント</span>
+      <span><%= @post.comment %></span>
+    </div>
+  </div>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,18 +1,3 @@
-<%# 下部広告部分 %>
-<div class='ad-footer-contents'>
-  <p class='ad-footer-explain'>
-    だれでもかんたん、人生を変えるアプリ
-  </p>
-  <h2 class='ad-footer-title'>
-    今すぐ無料ダウンロード！
-  </h2>
-  <div class='store-btn'>
-    <%# <%= link_to image_tag("app-store.svg", class:"apple-btn"), "#" %>
-    <%# <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
-  </div>
-</div>
-<%# /下部広告部分 %>
-
 <div class='footer'>
   <div class='footer-contents'>
     <div class='rs-details'>

--- a/app/views/shared/_leader.html.erb
+++ b/app/views/shared/_leader.html.erb
@@ -3,9 +3,24 @@
     <div class="leader">
       <span>…</span>
       <ul class="leader-lists">
+        <li class="leader-list"><%= link_to "詳細", post_path(post.id) %></li>
         <li class="leader-list"><%= link_to "編集", edit_post_path(post.id) %></li>
         <li class="leader-list"><%= link_to "削除", post_path(post.id), method: :delete %></li>
       </ul>
     </div>
+  <% else %>
+    <div class="leader">
+      <span>…</span>
+      <ul class="leader-lists">
+        <li class="leader-list"><%= link_to "詳細", post_path(post.id) %></li>
+      </ul>
+    </div>
   <% end %>
+<% else %>
+  <div class="leader">
+    <span>…</span>
+    <ul class="leader-lists">
+      <li class="leader-list"><%= link_to "詳細", post_path(post.id) %></li>
+    </ul>
+  </div>
 <% end %>

--- a/app/views/shared/_second-leader.html.erb
+++ b/app/views/shared/_second-leader.html.erb
@@ -1,0 +1,11 @@
+<% if user_signed_in? %>
+  <% if current_user.id == post.user.id %>
+    <div class="leader">
+      <span>…</span>
+      <ul class="leader-lists">
+        <li class="leader-list"><%= link_to "編集", edit_post_path(post.id) %></li>
+        <li class="leader-list"><%= link_to "削除", post_path(post.id), method: :delete %></li>
+      </ul>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,7 +15,7 @@
           <% end %>
         </div>
 
-        <%= render "shared/leader", post: post %>
+        <%= render "shared/second-leader", post: post %>
 
         <div class='index-image'>
           <%= image_tag post.image, class: 'post-image' if post.image.attached? %>
@@ -29,7 +29,7 @@
         </div>
         <div class='map-comment'>
           <span class="box-title">コメント</span>
-          <span><%= post.comment %></span>
+          <span><%= truncate(post.comment, length: 40) %></span>
         </div>
       </div>
     </li>


### PR DESCRIPTION
# What
投稿詳細機能の実装

# Why
投稿詳細表示ページにて、投稿の情報をより詳細に表示するため

# gyazoのURL
ログイン状態且つ、自身が投稿した投稿詳細ページへ遷移した動画
https://gyazo.com/435a325f509c778218e019cf408055ea

ログイン状態且つ、自身が投稿していない投稿詳細ページへ遷移し、「投稿の編集」「削除」ボタンが表示されない動画
https://gyazo.com/5c94c43334fbb9333c43025903728eb0

ログアウト状態で、投稿詳細ページへ遷移し、「投稿の編集」「削除」ボタンが表示されない動画
https://gyazo.com/ef18ef5a64924e0863b7185fbd2d28b0